### PR TITLE
Update CLKeySearchDevice.cpp

### DIFF
--- a/CLKeySearchDevice/CLKeySearchDevice.cpp
+++ b/CLKeySearchDevice/CLKeySearchDevice.cpp
@@ -575,7 +575,7 @@ void CLKeySearchDevice::generateStartingPoints()
 
 secp256k1::uint256 CLKeySearchDevice::getNextKey()
 {
-    uint64_t totalPoints = (uint64_t)_points * _threads * _blocks;
+    uint64_t totalPoints = (uint64_t)_points ;
 
     return _start + secp256k1::uint256(totalPoints) * _iterations * _stride;
 }


### PR DESCRIPTION
This seems to fix the bug "Reached end of keyspace" too soon.